### PR TITLE
th-85: Checking on existing business before creating user

### DIFF
--- a/backend/src/libs/packages/database/generated-schema/0005_del_company_name_unique_index.sql
+++ b/backend/src/libs/packages/database/generated-schema/0005_del_company_name_unique_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "business_details"
+DROP CONSTRAINT "business_details_company_name_unique";

--- a/backend/src/libs/packages/database/generated-schema/meta/0005_snapshot.json
+++ b/backend/src/libs/packages/database/generated-schema/meta/0005_snapshot.json
@@ -1,0 +1,220 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "8c454a9f-d718-42f1-8648-2c8da6a16918",
+  "prevId": "dd8363c1-1ee4-472f-93b3-cfe9bf6a5348",
+  "tables": {
+    "business_details": {
+      "name": "business_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_number": {
+          "name": "tax_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "business_details_owner_id_users_id_fk": {
+          "name": "business_details_owner_id_users_id_fk",
+          "tableFrom": "business_details",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "business_details_tax_number_unique": {
+          "name": "business_details_tax_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["tax_number"]
+        }
+      }
+    },
+    "groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_salt": {
+          "name": "password_salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_unique_idx": {
+          "name": "users_phone_unique_idx",
+          "columns": ["phone"],
+          "isUnique": true
+        },
+        "users_email_unique_idx": {
+          "name": "users_email_unique_idx",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_group_id_groups_id_fk": {
+          "name": "users_group_id_groups_id_fk",
+          "tableFrom": "users",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/backend/src/libs/packages/database/generated-schema/meta/_journal.json
+++ b/backend/src/libs/packages/database/generated-schema/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1693406907945,
       "tag": "0004_email_unique_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1693843703834,
+      "tag": "0005_del_company_name_unique_index",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/libs/packages/database/schema/tables-schema.ts
+++ b/backend/src/libs/packages/database/schema/tables-schema.ts
@@ -51,7 +51,7 @@ const usersRelations = relations(users, ({ one }) => ({
 
 const business = pgTable('business_details', {
   id: serial('id').primaryKey(),
-  companyName: varchar('company_name').unique().notNull(),
+  companyName: varchar('company_name').notNull(),
   taxNumber: varchar('tax_number').unique().notNull(),
   ownerId: integer('owner_id')
     .notNull()

--- a/backend/src/packages/business/business.service.ts
+++ b/backend/src/packages/business/business.service.ts
@@ -31,6 +31,15 @@ class BusinessService implements IService {
     return business ? BusinessEntity.initialize(business).toObject() : null;
   }
 
+  public async checkIsExistingBusiness(
+    key: Pick<BusinessEntityT, 'taxNumber'>,
+  ): Promise<boolean> {
+    const { result: doesBusinessExist } =
+      await this.businessRepository.checkExists(key);
+
+    return doesBusinessExist;
+  }
+
   public async create({
     payload,
     owner,
@@ -46,7 +55,6 @@ class BusinessService implements IService {
       await this.businessRepository.checkExists({
         id: owner.id,
         taxNumber: payload.taxNumber,
-        companyName: payload.companyName,
       });
 
     if (doesBusinessExist) {

--- a/backend/src/packages/users/user.service.ts
+++ b/backend/src/packages/users/user.service.ts
@@ -25,6 +25,16 @@ class UserService implements IService<UserEntityObjectT> {
     return result.map((item) => UserEntity.initialize(item).toObject());
   }
 
+  public async findByPhoneOrEmail(
+    phone: UserEntityT['phone'],
+    email: UserEntityT['email'],
+  ): Promise<(UserEntityT & { createdAt: Date; updatedAt: Date }) | null> {
+    return await this.userRepository.findByPhoneOrEmail({
+      phone,
+      email,
+    });
+  }
+
   public async findByPhone(
     phone: UserEntityT['phone'],
   ): Promise<UserEntityObjectWithGroupT | null> {

--- a/shared/src/libs/packages/http/libs/enums/http-error-message.enum.ts
+++ b/shared/src/libs/packages/http/libs/enums/http-error-message.enum.ts
@@ -1,5 +1,6 @@
 const HttpMessage = {
   USER_EXISTS: 'User already exists',
+  BUSINESS_EXISTS: 'Busines with specified tax number already exists',
   BUSINESS_ALREADY_EXISTS: 'Owner already has business!',
   NAME_ALREADY_REGISTERED: 'Business with such name already exists!',
   INVALID_USER_GROUP: 'User of the group cannot create business!',


### PR DESCRIPTION
The issues that resolve this bugfix:
While creating business user there are creating a user at first, recieve its ID fron db, then creating a busines connecting with user. But in this case we've encountered to the problem: if company name or taxNumber is the same to the existed one, BE send request with error but the user is already existed in db.  So he can't change company name and use sign-up form again.
1. That is why there was added the checking on the unique tax number before creating the entities user and busines. Added one more option of response - "Busines with specified tax number already exists".
2. The checking on company name uniqueness was removed and removed corresponding index in db.
3. Also was refactored method findByPhoneOrEmail for reducing a db calls.