### PR TITLE
th-311: Add rejected order status to 0015-snapshot.json

### DIFF
--- a/backend/src/libs/packages/database/generated-schema/meta/0015_snapshot.json
+++ b/backend/src/libs/packages/database/generated-schema/meta/0015_snapshot.json
@@ -716,6 +716,7 @@
         "pending": "pending",
         "confirmed": "confirmed",
         "canceled": "canceled",
+        "rejected": "rejected",
         "picking_up": "picking_up",
         "done": "done"
       }


### PR DESCRIPTION
This will resolve the issue with missed "rejected" order status in 0015-snapshot.
Without this, any following migration will contain redundant addition of this status to the order_status type.