### PR TITLE
th-383: Bug: When the driver logs out of the system, and another driver logs in, the shift is opened on the previous driver

### DIFF
--- a/frontend/src/libs/packages/socket/socket.package.ts
+++ b/frontend/src/libs/packages/socket/socket.package.ts
@@ -58,6 +58,12 @@ class SocketService {
     }
   }
 
+  public reconnect(): void {
+    this.io = io(config.ENV.API.SERVER_URL, {
+      transports: ['websocket', 'polling'],
+    });
+  }
+
   public checkIsConnected(): boolean {
     return this.io?.connected ?? false;
   }

--- a/frontend/src/slices/auth/actions.ts
+++ b/frontend/src/slices/auth/actions.ts
@@ -108,6 +108,8 @@ const authorizeDriverSocket = createAsyncThunk<
   async (userId, { extra, rejectWithValue }) => {
     const { socketClient } = extra;
 
+    socketClient.reconnect();
+
     const result = await socketClient.emitWithAck({
       event: ClientToServerEvent.AUTHORIZE_DRIVER,
       eventPayload: {


### PR DESCRIPTION
The problem was in following: When driver authorize and start shift then log out and another driver authorize and start shift during one socket connection, we have 2 different drivers in their own socket rooms under the same client socket id. So the event "start shift" was sent the first found.
In PR was added reconnect socket client while driver authorize.