### PR TITLE
th-401: Сhanges redirect link for business group

### DIFF
--- a/frontend/src/libs/components/header/libs/maps/user-group-to-redirect-link.map.ts
+++ b/frontend/src/libs/components/header/libs/maps/user-group-to-redirect-link.map.ts
@@ -7,7 +7,7 @@ const userGroupToRedirectLink: Record<
   ValueOf<typeof AppRoute>
 > = {
   [UserGroupKey.CUSTOMER]: AppRoute.ROOT,
-  [UserGroupKey.BUSINESS]: AppRoute.DASHBOARD,
+  [UserGroupKey.BUSINESS]: AppRoute.DASHBOARD_ORDERS,
   [UserGroupKey.DRIVER]: AppRoute.ORDERS,
 };
 

--- a/frontend/src/libs/enums/app-route.enum.ts
+++ b/frontend/src/libs/enums/app-route.enum.ts
@@ -9,7 +9,6 @@ const AppRoute = {
   EDIT_PROFILE: '/edit-profile',
   PROFILE: '/profile',
   TRUCKS: '/trucks',
-  DASHBOARD: '/dashboard',
   AVAILABLE_TRUCKS: '/available-trucks',
   ORDERS: '/orders',
   DRIVER_ORDER: '/orders/:orderId',


### PR DESCRIPTION
Changed the link for business group users since the dashboard route is not used. Also removed the `AppRoute.DASHBOARD` route to avoid confusion.